### PR TITLE
Display already existing user shelves during prompts

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -7,8 +7,8 @@ use super::ux;
 
 type BoxResult<T> = Result<T, Box<dyn Error>>;
 
-pub fn display_shelves(gr_client: &api_client::GoodreadsApiClient) -> BoxResult<()>{
-    match get_user_shelves(gr_client){
+pub fn display_shelves(gr_client: &api_client::GoodreadsApiClient) -> BoxResult<()> {
+    match get_user_shelves(gr_client) {
         Ok(shelves) => {
             if shelves.len() == 0 {
                 return Ok(());
@@ -18,18 +18,20 @@ pub fn display_shelves(gr_client: &api_client::GoodreadsApiClient) -> BoxResult<
                 println!("- {}", shelf.name);
             }
             Ok(())
-        },
+        }
         Err(err) => bail!("Error: {}", err),
     }
 }
 
-pub fn get_user_shelves(gr_client: &api_client::GoodreadsApiClient) -> Result<Vec<models::UserShelf>, String> {
-    let res = gr_client.list_shelves().and_then(|xml| {
-        match models::parse_shelves(&xml) {
+pub fn get_user_shelves(
+    gr_client: &api_client::GoodreadsApiClient,
+) -> Result<Vec<models::UserShelf>, String> {
+    let res = gr_client
+        .list_shelves()
+        .and_then(|xml| match models::parse_shelves(&xml) {
             Ok(shelves) => Ok(shelves),
             Err(err) => Err(format!("Error: {:?}", err)),
-        }
-    });
+        });
     match res {
         Ok(shelves) => Ok(shelves),
         Err(err) => Err(err.to_string()),

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 
 pub mod goodreads_api_endpoints {
     pub const USER_ID: &str = "https://www.goodreads.com/api/auth_user";
+    pub const LIST_SHELVES: &str = "https://www.goodreads.com/shelf/list.xml";
     pub const LIST_SHELF: &str = "https://www.goodreads.com/review/list?v=2";
     pub const ADD_TO_SHELF: &str = "https://www.goodreads.com/shelf/add_to_shelf.xml";
     pub const UPDATE_STATUS: &str = "https://www.goodreads.com/user_status.json";
@@ -217,6 +218,32 @@ impl GoodreadsApiClient {
         }
     }
 
+    pub fn list_shelves(&self) -> Result<String, String> {
+        let mut req_params = HashMap::new();
+        let _ = req_params.insert(Cow::from("id"), Cow::from(self.user_id.to_string()));
+        let _ = req_params.insert(Cow::from("key"), Cow::from(self.auth.developer_key.clone()));
+
+        let res = make_oauthd_request(
+            self,
+            reqwest::Method::GET,
+            goodreads_api_endpoints::LIST_SHELVES,
+            Some(&req_params),
+        );
+
+        match res {
+            Ok(mut resp) => {
+                if resp.status() == StatusCode::OK {
+                    Ok(resp.text().unwrap())
+                } else {
+                    Err(format!(
+                        "Request failed. Response status: {}",
+                        resp.status()
+                    ))
+                }
+            }
+            Err(err) => Err(format!("Request failed: {}", err)),
+        }
+    }
     pub fn new(
         user_id: u32,
         developer_key: &str,

--- a/src/api_responses/user_shelves_resp.xml
+++ b/src/api_responses/user_shelves_resp.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GoodreadsResponse>
+    <Request>
+        <authentication>true</authentication>
+        <key>
+            <![CDATA[cTkofm5VpGWPLufIrnbOw]]>
+        </key>
+        <method>
+            <![CDATA[shelf_list]]>
+        </method>
+    </Request>
+    <shelves start="1" end="3" total="3">
+        <user_shelf>
+            <id type="integer">7686882</id>
+            <name>read</name>
+            <book_count type="integer">0</book_count>
+            <exclusive_flag type="boolean">true</exclusive_flag>
+            <description nil="true"/>
+            <sort nil="true"/>
+            <order nil="true"/>
+            <per_page type="integer" nil="true"/>
+            <display_fields></display_fields>
+            <featured type="boolean">true</featured>
+            <recommend_for type="boolean">true</recommend_for>
+            <sticky type="boolean" nil="true"/>
+        </user_shelf>
+        <user_shelf>
+            <id type="integer">37431</id>
+            <name>currently-reading</name>
+            <book_count type="integer">0</book_count>
+            <exclusive_flag type="boolean">true</exclusive_flag>
+            <description nil="true"/>
+            <sort nil="true"/>
+            <order nil="true"/>
+            <per_page type="integer" nil="true"/>
+            <display_fields></display_fields>
+            <featured type="boolean">false</featured>
+            <recommend_for type="boolean">true</recommend_for>
+            <sticky type="boolean" nil="true"/>
+        </user_shelf>
+        <user_shelf>
+            <id type="integer">37430</id>
+            <name>to-read</name>
+            <book_count type="integer">0</book_count>
+            <exclusive_flag type="boolean">true</exclusive_flag>
+            <description nil="true"/>
+            <sort nil="true"/>
+            <order>a</order>
+            <per_page type="integer" nil="true"/>
+            <display_fields></display_fields>
+            <featured type="boolean">false</featured>
+            <recommend_for type="boolean">true</recommend_for>
+            <sticky type="boolean" nil="true"/>
+        </user_shelf>
+    </shelves>
+</GoodreadsResponse>

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,7 +5,8 @@ use roxmltree::Node;
 
 const MAX_DESC_LEN: usize = 20;
 
-/// This struct only display
+/// This struct is only uses during LIST requests for the names of the currently existing shelves
+/// for a user. It is different from the Shelf struct which contains which books are actually on a shelf
 #[derive(Debug, Default)]
 pub struct UserShelf {
     pub id: String,

--- a/src/models.rs
+++ b/src/models.rs
@@ -133,7 +133,7 @@ pub fn parse_shelf(shelf_xml: &str) -> Result<Shelf, roxmltree::Error> {
 
 pub fn parse_shelves(shelves_xml: &str) -> Result<Vec<UserShelf>, roxmltree::Error> {
     let mut user_shelves: Vec<UserShelf> = Vec::new();
-    let doc = match roxmltree::Document::parse(shelves_xml){
+    let doc = match roxmltree::Document::parse(shelves_xml) {
         Ok(doc) => doc,
         Err(e) => {
             println!("Error: {}", e);
@@ -141,7 +141,7 @@ pub fn parse_shelves(shelves_xml: &str) -> Result<Vec<UserShelf>, roxmltree::Err
         }
     };
 
-    for node in doc.descendants(){
+    for node in doc.descendants() {
         if node.is_element() && node.has_tag_name("user_shelf") {
             user_shelves.push(user_shelf_from_xml_node(node));
         }
@@ -177,10 +177,20 @@ fn extract_book_id_from_book_link(book_link: &str) -> Option<u32> {
 
 fn user_shelf_from_xml_node(node: Node) -> UserShelf {
     let mut us = UserShelf::default();
-    for child_node in node.descendants(){
-        match child_node.tag_name().name(){
-            "id" => us.id = child_node.text().expect("Expected ID node in user_shelf node").to_owned(),
-            "name" => us.name = child_node.text().expect("Expected name node in user_shelf node").to_owned(),
+    for child_node in node.descendants() {
+        match child_node.tag_name().name() {
+            "id" => {
+                us.id = child_node
+                    .text()
+                    .expect("Expected ID node in user_shelf node")
+                    .to_owned()
+            }
+            "name" => {
+                us.name = child_node
+                    .text()
+                    .expect("Expected name node in user_shelf node")
+                    .to_owned()
+            }
             _ => {}
         }
     }
@@ -248,20 +258,20 @@ mod tests {
     //        parse_shelf(&text);
     //    }
 
-       #[test]
-       fn test_parse_user_shelves() {
-           let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-           path.push("src/api_responses/user_shelves_resp.xml");
-           println!("{}", path.display());
-           let text = load_file(&path);
-           let shelves = parse_shelves(&text).expect("Failed parsing user_shelves_resp.xml");
-           assert_eq!(shelves.len(), 3);
+    #[test]
+    fn test_parse_user_shelves() {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("src/api_responses/user_shelves_resp.xml");
+        println!("{}", path.display());
+        let text = load_file(&path);
+        let shelves = parse_shelves(&text).expect("Failed parsing user_shelves_resp.xml");
+        assert_eq!(shelves.len(), 3);
 
-           let shelf_names = vec!("read", "currently-reading", "to-read");
-           for (i, shelf) in  shelves.iter().enumerate() {
-               assert_eq!(shelf.name, shelf_names[i]);
-           }
-       }
+        let shelf_names = vec!["read", "currently-reading", "to-read"];
+        for (i, shelf) in shelves.iter().enumerate() {
+            assert_eq!(shelf.name, shelf_names[i]);
+        }
+    }
 
     #[test]
     fn test_extract_book_id_from_book_link() {


### PR DESCRIPTION
During some prompts when you have to select a shelf, I thought it would be nice to see the names of the shelves that actually exist. 

I had a really tough time figuring out how to return Errors, so I would appreciate some help refactoring that.